### PR TITLE
ZQS-1020: fixed bug with qiskit 0.34

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
     # Run jobs for a couple of Python versions.
     strategy:
       matrix:
-        python: ["3.8", "3.9"]
+        python: ["3.8", "3.9", "3.10"]
 
     name: TestCoverage - Python ${{ matrix.python }}
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -22,7 +22,7 @@ jobs:
     # Run jobs for a couple of Python versions.
     strategy:
       matrix:
-        python: ["3.8", "3.9"]
+        python: ["3.8", "3.9", "3.10"]
 
     name: Style - Python ${{ matrix.python }}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,14 +21,13 @@ include_package_data = True
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >=3.8,!=3.9.7
+python_requires = >=3.8,!=3.9.7,<3.11
 
 install_requires =
     numpy>=1.20
     scipy>=1.4.1
     sympy>=1.5,<=1.9
     qiskit>=0.28, <=0.34
-    qiskit-ibmq-provider~=0.15
     symengine~=0.7
     orquestra-quantum
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,13 +21,13 @@ include_package_data = True
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >=3.8,!=3.9.7,<3.10
+python_requires = >=3.8,!=3.9.7
 
 install_requires =
     numpy>=1.20
     scipy>=1.4.1
     sympy>=1.5,<=1.9
-    qiskit>=0.28, <0.34
+    qiskit>=0.28, <=0.34
     qiskit-ibmq-provider~=0.15
     symengine~=0.7
     orquestra-quantum

--- a/src/orquestra/integrations/qiskit/simulator/simulator.py
+++ b/src/orquestra/integrations/qiskit/simulator/simulator.py
@@ -149,7 +149,7 @@ class QiskitSimulator(QuantumSimulator):
         Args:
             circuit (zquantum.core.circuit.Circuit): the circuit to prepare the state
         Returns:
-            pyquil.wavefunction.Wavefunction
+            zquantum.core.wavefunction.Wavefunction
         """
         ibmq_circuit = export_to_qiskit(circuit)
 
@@ -176,4 +176,4 @@ class QiskitSimulator(QuantumSimulator):
             seed_transpiler=self.seed,
         )
         wavefunction = job.result().get_statevector(ibmq_circuit, decimals=20)
-        return flip_amplitudes(wavefunction)
+        return flip_amplitudes(wavefunction.data)


### PR DESCRIPTION
## Description

This PR contains a minor fix to the code such that the tests pass for `qiskit==0.34`, which is needed if we want to support Python 3.10. The fix is simply adding `.data` to the `Statevector` object from `qiskit`, which then allows the code in `orquestra.quantum.Wavefunction.flip_amplitudes` to now pass.

Changes were made in the setup to allow for installing Python 3.10, and `qiskit<=0.34` 

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix. <--- the failing tests are now passing 
- [x] I have updated documentation.
