### PR TITLE
feat: better error message when token is missing

### DIFF
--- a/src/orquestra/integrations/qiskit/noise/basic.py
+++ b/src/orquestra/integrations/qiskit/noise/basic.py
@@ -14,7 +14,7 @@ from qiskit.providers.aer.noise import (
     phase_damping_error,
 )
 from qiskit.providers.ibmq import IBMQ
-from qiskit.providers.ibmq.exceptions import IBMQAccountError
+from qiskit.providers.ibmq.exceptions import IBMQAccountError, IBMQProviderError
 from qiskit.quantum_info import Kraus
 
 
@@ -47,9 +47,15 @@ def get_qiskit_noise_model(
                 raise RuntimeError(e)
 
     # Get qiskit noise model from qiskit
-    provider = IBMQ.get_provider(hub=hub, group=group, project=project)
-    noisy_device = provider.get_backend(device_name)
+    try:
+        provider = IBMQ.get_provider(hub=hub, group=group, project=project)
+    except IBMQProviderError as e:
+        if api_token is None:
+            raise RuntimeError("No providers were found. Missing IBMQ API token?")
+        else:
+            raise RuntimeError(e)
 
+    noisy_device = provider.get_backend(device_name)
     noise_model = AerNoise.NoiseModel.from_backend(noisy_device)
     coupling_map = noisy_device.configuration().coupling_map
 

--- a/tests/orquestra/integrations/qiskit/noise/basic_test.py
+++ b/tests/orquestra/integrations/qiskit/noise/basic_test.py
@@ -21,7 +21,7 @@ from orquestra.integrations.qiskit.noise.basic import (
 class TestBasic(unittest.TestCase):
     def setUp(self):
         self.ibmq_api_token = os.getenv("ZAPATA_IBMQ_API_TOKEN")
-        self.all_devices = ["ibmq_santiago"]
+        self.all_devices = ["ibm_nairobi"]
         self.T_1 = 10e-7
         self.T_2 = 30e-7
         self.t_step = 10e-9

--- a/tests/orquestra/integrations/qiskit/simulator/simulator_test.py
+++ b/tests/orquestra/integrations/qiskit/simulator/simulator_test.py
@@ -64,7 +64,7 @@ def sampling_simulator(request):
 def noisy_simulator(request):
     ibmq_api_token = os.getenv("ZAPATA_IBMQ_API_TOKEN")
     noise_model, connectivity = get_qiskit_noise_model(
-        "ibmq_santiago", api_token=ibmq_api_token
+        "ibm_nairobi", api_token=ibmq_api_token
     )
 
     return QiskitSimulator(
@@ -179,7 +179,7 @@ class TestQiskitSimulator(QuantumSimulatorTests):
     def test_optimization_level_of_transpiler(self):
         # Given
         noise_model, connectivity = get_qiskit_noise_model(
-            "ibmq_santiago", api_token=os.getenv("ZAPATA_IBMQ_API_TOKEN")
+            "ibm_nairobi", api_token=os.getenv("ZAPATA_IBMQ_API_TOKEN")
         )
         n_samples = 20000
         simulator = QiskitSimulator(


### PR DESCRIPTION
## Description

Include description of feature this PR introduces or a bug that it fixes. Include the following information:

- Context: why is it needed? In case of bug, what was the cause for the bug?
When a token is needed to initialize IBMQ providers and we fail to provide one,  `IBMQ.get_provider()`  will fail with the following error message: `No provider matches the specified criteria`, which is misleading and causes confusion.
- Concise description of the implemented solution.
IBMQProviderError is the only error that `IBMQ.get_provider()` could raise (see source code [here](https://github.com/Qiskit/qiskit-ibmq-provider/blob/master/qiskit/providers/ibmq/ibmqfactory.py#L422)). If we see this error and `api_token` is `None`, we will let the user know from our error message that the failure might be due to missing API token.
- If any dependencies are added, list them and justify why they are needed.
No dependencies are added.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
