### PR TITLE
Virtual to physical mapping

### DIFF
--- a/src/orquestra/integrations/qiskit/backend/backend.py
+++ b/src/orquestra/integrations/qiskit/backend/backend.py
@@ -333,7 +333,7 @@ class QiskitBackend(QuantumBackend):
                     )
                 circuit_index += 1
 
-            #Get virtual to physical qubit mapping
+            # Get virtual to physical qubit mapping
             virtual_to_physical_qubits_dict = _get_virtual_to_physical_qubits_dict(
                 current_circuit_from_batches, current_circuit_from_jobs
             )
@@ -354,8 +354,10 @@ class QiskitBackend(QuantumBackend):
                 reversed_counts[bitstring[::-1]] = int(combined_counts[bitstring])
 
             measurements = Measurements.from_counts(reversed_counts)
-            #Virtual to phyiscal mapping is part of measuremnts class
-            measurements.virtual_to_physical_qubits_dict = virtual_to_physical_qubits_dict
+            # Virtual to phyiscal mapping is part of measuremnts class
+            measurements.virtual_to_physical_qubits_dict = (
+                virtual_to_physical_qubits_dict
+            )
             measurements_set.append(measurements)
 
         return measurements_set
@@ -441,7 +443,8 @@ class QiskitBackend(QuantumBackend):
 
 
 def _get_active_qubits(circuit: QuantumCircuit) -> Set[int]:
-    """Returns a list of qubits that qiskit gates are operating on (i.e., active qubits).
+    """Returns a list of qubits that qiskit gates are
+       operating on (i.e., active qubits).
 
     Args:
         circuit (QuantumCircuit): a circuit that we want to find the active qubits for.

--- a/src/orquestra/integrations/qiskit/backend/backend.py
+++ b/src/orquestra/integrations/qiskit/backend/backend.py
@@ -333,14 +333,16 @@ class QiskitBackend(QuantumBackend):
                     )
                 circuit_index += 1
 
+            #Get virtual to physical qubit mapping
+            virtual_to_physical_qubits_dict = _get_virtual_to_physical_qubits_dict(
+                current_circuit_from_batches, current_circuit_from_jobs
+            )
+
             if self.readout_correction:
                 current_circuit_from_jobs = circuit_set_from_jobs[circuit_index - 1]
                 current_circuit_from_batches = circuit_set_from_batches[
                     circuit_index - 1
                 ]
-                virtual_to_physical_qubits_dict = _get_virtual_to_physical_qubits_dict(
-                    current_circuit_from_batches, current_circuit_from_jobs
-                )
                 combined_counts = self._apply_readout_correction(
                     combined_counts, virtual_to_physical_qubits_dict
                 )
@@ -352,6 +354,8 @@ class QiskitBackend(QuantumBackend):
                 reversed_counts[bitstring[::-1]] = int(combined_counts[bitstring])
 
             measurements = Measurements.from_counts(reversed_counts)
+            #Virtual to phyiscal mapping is part of measuremnts class
+            measurements.virtual_to_physical_qubits_dict = virtual_to_physical_qubits_dict
             measurements_set.append(measurements)
 
         return measurements_set


### PR DESCRIPTION
I am moving the virtual to physical dictionary (that Amara created) outside the if statement for measurement error correction. This way, the virtual to physical mapping is returned with the counts inside the Measurements object. This information is necessary for our custom error mitigation techniques which are performed in post.

