### PR TITLE
ZQS 1104: New pauli operator data structures

### DIFF
--- a/src/orquestra/integrations/qiskit/conversions/__init__.py
+++ b/src/orquestra/integrations/qiskit/conversions/__init__.py
@@ -2,4 +2,4 @@
 # © Copyright 2021-2022 Zapata Computing Inc.
 ################################################################################
 from ._circuit_conversions import export_to_qiskit, import_from_qiskit
-from ._openfermion_conversions import qiskitpauli_to_qubitop, qubitop_to_qiskitpauli
+from ._pauli_conversions import qiskitpauli_to_qubitop, qubitop_to_qiskitpauli

--- a/src/orquestra/integrations/qiskit/conversions/_pauli_conversions.py
+++ b/src/orquestra/integrations/qiskit/conversions/_pauli_conversions.py
@@ -18,7 +18,6 @@
 """
 Translates OpenFermion Objects to qiskit SummedOp objects
 """
-from orquestra.quantum.openfermion import count_qubits
 from orquestra.quantum.wip.operators import PauliRepresentation, PauliSum, PauliTerm
 from qiskit.opflow import PauliOp, SummedOp
 from qiskit.quantum_info import Pauli
@@ -38,7 +37,7 @@ def qubitop_to_qiskitpauli(operator: PauliRepresentation) -> SummedOp:
 
     terms = []
     for term in operator.terms:
-        string_term = "I" * count_qubits(operator)
+        string_term = "I" * len(operator)
         for term_qubit, term_pauli in term._ops.items():
             string_term = (
                 string_term[:term_qubit] + term_pauli + string_term[term_qubit + 1 :]

--- a/src/orquestra/integrations/qiskit/conversions/_pauli_conversions.py
+++ b/src/orquestra/integrations/qiskit/conversions/_pauli_conversions.py
@@ -18,61 +18,64 @@
 """
 Translates OpenFermion Objects to qiskit SummedOp objects
 """
-from orquestra.quantum.openfermion import QubitOperator, count_qubits
+from orquestra.quantum.openfermion import count_qubits
+from orquestra.quantum.wip.operators import PauliRepresentation, PauliSum, PauliTerm
 from qiskit.opflow import PauliOp, SummedOp
 from qiskit.quantum_info import Pauli
 
 
-def qubitop_to_qiskitpauli(qubit_operator: QubitOperator) -> SummedOp:
-    """Convert a OpenFermion QubitOperator to a SummedOp.
+def qubitop_to_qiskitpauli(operator: PauliRepresentation) -> SummedOp:
+    """Convert a PauliRepresentation to a SummedOp.
 
     Args:
-        qubit_operator: OpenFermion QubitOperator to convert
+        operator: PauliRepresentation to convert
 
     Returns:
         SummedOp representing the qubit operator
     """
-    if not isinstance(qubit_operator, QubitOperator):
-        raise TypeError("qubit_operator must be an OpenFermion QubitOperator object")
+    if not isinstance(operator, PauliSum) and not isinstance(operator, PauliTerm):
+        raise TypeError("operator must be an Orquestra PauliSum or PauliTerm object")
 
     terms = []
-    for qubit_terms, coefficient in qubit_operator.terms.items():
-        string_term = "I" * count_qubits(qubit_operator)
-        for i, (term_qubit, term_pauli) in enumerate(qubit_terms):
+    for term in operator.terms:
+        string_term = "I" * count_qubits(operator)
+        for term_qubit, term_pauli in term._ops.items():
             string_term = (
                 string_term[:term_qubit] + term_pauli + string_term[term_qubit + 1 :]
             )
-        terms.append(PauliOp(Pauli.from_label(string_term), coeff=coefficient))
+        terms.append(PauliOp(Pauli.from_label(string_term), coeff=term.coefficient))
 
     return SummedOp(terms)
 
 
-def qiskitpauli_to_qubitop(qiskit_pauli: SummedOp) -> QubitOperator:
-    """Convert a qiskit's SummedOp to an OpenFermion QubitOperator.
+def qiskitpauli_to_qubitop(qiskit_pauli: SummedOp) -> PauliSum:
+    """Convert a qiskit's SummedOp to a PauliSum.
 
     Args:
         qiskit_pauli: operator to convert
 
     Returns:
-        QubitOperator representing the SummedOp
+        PauliSum representing the SummedOp
     """
 
     if not isinstance(qiskit_pauli, SummedOp):
         raise TypeError("qiskit_pauli must be a qiskit SummedOp")
 
-    transformed_term = QubitOperator()
+    transformed_operator = PauliSum()
 
     for pauli_op in qiskit_pauli._oplist:
         qiskit_term, weight = pauli_op.primitive, pauli_op.coeff
 
-        openfermion_term = QubitOperator()
+        orquestra_term = PauliTerm.identity()
         for (term_qubit, term_pauli) in enumerate(str(qiskit_term)):
             if term_pauli != "I":
-                if openfermion_term == QubitOperator():
-                    openfermion_term = QubitOperator(f"[{term_pauli}{term_qubit}]")
+                if orquestra_term == PauliTerm.identity():
+                    orquestra_term = PauliTerm(f"{term_pauli}{term_qubit}")
                 else:
-                    openfermion_term *= QubitOperator(f"[{term_pauli}{term_qubit}]")
+                    product = PauliTerm(f"{term_pauli}{term_qubit}") * orquestra_term
+                    assert isinstance(product, PauliTerm)
+                    orquestra_term = product
 
-        transformed_term += openfermion_term * weight
+        transformed_operator += orquestra_term * weight
 
-    return transformed_term
+    return transformed_operator

--- a/tests/orquestra/integrations/qiskit/conversions/pauli_conversions_test.py
+++ b/tests/orquestra/integrations/qiskit/conversions/pauli_conversions_test.py
@@ -54,7 +54,7 @@ def test_paulisum_to_qiskitpauli():
     """
     Conversion of PauliSum to qiskit SummedOp; accuracy test
     """
-    pauli_term = PauliSum.from_str("0.5*X0*Z1*X2") + PauliSum.from_str("0.5*Y0*Z1*Y2")
+    pauli_term = PauliSum.from_str("0.5*X0*Z1*X2 + 0.5*Y0*Z1*Y2")
 
     qiskit_op = qubitop_to_qiskitpauli(pauli_term)
 

--- a/tests/orquestra/integrations/qiskit/conversions/pauli_conversions_test.py
+++ b/tests/orquestra/integrations/qiskit/conversions/pauli_conversions_test.py
@@ -21,10 +21,8 @@ from orquestra.quantum.openfermion.ops import (
     FermionOperator,
     InteractionOperator,
     InteractionRDM,
-    QubitOperator,
 )
-from orquestra.quantum.openfermion.transforms import jordan_wigner
-from orquestra.quantum.openfermion.utils import hermitian_conjugated
+from orquestra.quantum.wip.operators import PauliSum, PauliTerm
 from qiskit.opflow import PauliOp, SummedOp
 from qiskit.quantum_info import Pauli
 
@@ -52,14 +50,11 @@ def test_translation_type_enforcement():
         qubitop_to_qiskitpauli(interact_rdm)
 
 
-def test_qubitop_to_qiskitpauli():
+def test_paulisum_to_qiskitpauli():
     """
-    Conversion of QubitOperator; accuracy test
+    Conversion of PauliSum to qiskit SummedOp; accuracy test
     """
-    hop_term = FermionOperator(((2, 1), (0, 0)))
-    term = hop_term + hermitian_conjugated(hop_term)
-
-    pauli_term = jordan_wigner(term)
+    pauli_term = PauliSum.from_str("0.5*X0*Z1*X2") + PauliSum.from_str("0.5*Y0*Z1*Y2")
 
     qiskit_op = qubitop_to_qiskitpauli(pauli_term)
 
@@ -70,8 +65,21 @@ def test_qubitop_to_qiskitpauli():
     assert ground_truth == qiskit_op
 
 
+def test_pauliterm_to_qiskitpauli():
+    """
+    Conversion of PauliTerm to qiskit SummedOp; accuracy test
+    """
+    pauli_term = PauliTerm.from_str("2.25*Y0*X1*Z2*X4")
+
+    qiskit_op = qubitop_to_qiskitpauli(pauli_term)
+
+    ground_truth = SummedOp([PauliOp(Pauli.from_label("YXZIX"), 2.25)])
+
+    assert ground_truth == qiskit_op
+
+
 def test_qubitop_to_qiskitpauli_zero():
-    zero_term = QubitOperator()
+    zero_term = PauliSum()
     qiskit_term = qubitop_to_qiskitpauli(zero_term)
     ground_truth = SummedOp([])
 
@@ -79,12 +87,15 @@ def test_qubitop_to_qiskitpauli_zero():
 
 
 def test_qiskitpauli_to_qubitop():
+    """
+    Conversion of qiskit SummedOp to PauliSum; accuracy test
+    """
     qiskit_term = SummedOp([PauliOp(Pauli.from_label("XIIIIY"), coeff=1)])
 
-    op_fermion_term = QubitOperator(((0, "X"), (5, "Y")))
-    test_op_fermion_term = qiskitpauli_to_qubitop(qiskit_term)
+    expected_pauli_term = PauliTerm.from_list([("X", 0), ("Y", 5)])
+    test_pauli_term = qiskitpauli_to_qubitop(qiskit_term)
 
-    assert test_op_fermion_term.isclose(op_fermion_term)
+    assert test_pauli_term == expected_pauli_term
 
 
 def test_qiskitpauli_to_qubitop_type_enforced():

--- a/tests/orquestra/integrations/qiskit/simulator/simulator_test.py
+++ b/tests/orquestra/integrations/qiskit/simulator/simulator_test.py
@@ -13,7 +13,7 @@ from orquestra.quantum.api.estimation import EstimationTask
 from orquestra.quantum.circuits import CNOT, Circuit, X
 from orquestra.quantum.estimation import estimate_expectation_values_by_averaging
 from orquestra.quantum.measurements import ExpectationValues
-from orquestra.quantum.openfermion.ops import QubitOperator
+from orquestra.quantum.wip.operators import PauliTerm
 
 from orquestra.integrations.qiskit.noise import get_qiskit_noise_model
 from orquestra.integrations.qiskit.simulator import QiskitSimulator
@@ -127,7 +127,7 @@ class TestQiskitSimulator(QuantumSimulatorTests):
         # Flip qubit an even number of times to remain in the |1> state, but allow
         # decoherence to take effect
         circuit += Circuit([X(0) for i in range(10)])
-        qubit_operator = QubitOperator("Z0")
+        qubit_operator = PauliTerm("Z0")
         n_samples = 8192
         # When
 
@@ -154,7 +154,7 @@ class TestQiskitSimulator(QuantumSimulatorTests):
         # Flip qubit an even number of times to remain in the |1> state, but allow
         # decoherence to take effect
         circuit += Circuit([X(0) for i in range(50)])
-        qubit_operator = QubitOperator("Z0")
+        qubit_operator = PauliTerm("Z0")
         # When
         estimation_tasks = [EstimationTask(qubit_operator, circuit, n_samples)]
 
@@ -188,7 +188,7 @@ class TestQiskitSimulator(QuantumSimulatorTests):
             device_connectivity=connectivity,
             optimization_level=0,
         )
-        qubit_operator = QubitOperator("Z0")
+        qubit_operator = PauliTerm("Z0")
         # Initialize in |1> state
         circuit = Circuit([X(0)])
         # Flip qubit an even number of times to remain in the |1> state, but allow


### PR DESCRIPTION
## Description

Migrate our code from using openfermion's QubitOperator to our own PauliTerm and PauliSum.

Checks fail because they depend on changes in https://github.com/zapatacomputing/orquestra-quantum/pull/45

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
