### PR TITLE
Implement conversion of Delay instructions

### DIFF
--- a/src/orquestra/integrations/qiskit/conversions/_circuit_conversions.py
+++ b/src/orquestra/integrations/qiskit/conversions/_circuit_conversions.py
@@ -56,7 +56,7 @@ ORQUESTRA_QISKIT_GATE_MAP = {
     _builtin_gates.YY: qiskit.circuit.library.RYYGate,
     _builtin_gates.ZZ: qiskit.circuit.library.RZZGate,
     _builtin_gates.U3: qiskit.circuit.library.U3Gate,
-    _builtin_gates.Delay: qiskit.circuit.Delay
+    _builtin_gates.Delay: qiskit.circuit.Delay,
 }
 
 

--- a/src/orquestra/integrations/qiskit/conversions/_circuit_conversions.py
+++ b/src/orquestra/integrations/qiskit/conversions/_circuit_conversions.py
@@ -56,6 +56,7 @@ ORQUESTRA_QISKIT_GATE_MAP = {
     _builtin_gates.YY: qiskit.circuit.library.RYYGate,
     _builtin_gates.ZZ: qiskit.circuit.library.RZZGate,
     _builtin_gates.U3: qiskit.circuit.library.U3Gate,
+    _builtin_gates.Delay: qiskit.circuit.Delay
 }
 
 

--- a/tests/orquestra/integrations/qiskit/conversions/circuit_conversions_test.py
+++ b/tests/orquestra/integrations/qiskit/conversions/circuit_conversions_test.py
@@ -272,6 +272,10 @@ EQUIVALENT_NON_PARAMETRIZED_CIRCUITS = [
             ],
         ),
     ),
+    (
+        _circuit.Circuit([_builtin_gates.Delay(1)(0)]),
+        _make_qiskit_circuit(1, [("delay", (1, 0))])
+    )
 ]
 
 

--- a/tests/orquestra/integrations/qiskit/conversions/circuit_conversions_test.py
+++ b/tests/orquestra/integrations/qiskit/conversions/circuit_conversions_test.py
@@ -274,8 +274,8 @@ EQUIVALENT_NON_PARAMETRIZED_CIRCUITS = [
     ),
     (
         _circuit.Circuit([_builtin_gates.Delay(1)(0)]),
-        _make_qiskit_circuit(1, [("delay", (1, 0))])
-    )
+        _make_qiskit_circuit(1, [("delay", (1, 0))]),
+    ),
 ]
 
 


### PR DESCRIPTION
Co-authored-by: ucapgum <george.umbrarescu@zapatacomputing.com>

## Description
This follows up the introduction of the `Delay` gate to `orquestra-quantum` by adding conversion rules to and from its `qiskit`'s equivalent.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
