### PR TITLE
feat: added provider to QiskitBackend

### DIFF
--- a/src/orquestra/integrations/qiskit/backend/backend.py
+++ b/src/orquestra/integrations/qiskit/backend/backend.py
@@ -88,7 +88,7 @@ class QiskitBackend(QuantumBackend):
             else:
                 raise RuntimeError(e)
 
-        self.device = provider.get_backend(name=self.device_name)
+        self.device = self.provider.get_backend(name=self.device_name)
         self.max_shots = self.device.configuration().max_shots
         self.batch_size: int = self.device.configuration().max_experiments
         self.supports_batching = True

--- a/src/orquestra/integrations/qiskit/backend/backend.py
+++ b/src/orquestra/integrations/qiskit/backend/backend.py
@@ -79,8 +79,9 @@ class QiskitBackend(QuantumBackend):
                 ):
                     raise RuntimeError(e)
 
+        self.provider = None
         try:
-            provider = IBMQ.get_provider(hub=hub, group=group, project=project)
+            self.provider = IBMQ.get_provider(hub=hub, group=group, project=project)
         except IBMQProviderError as e:
             if api_token is None:
                 raise RuntimeError("No providers were found. Missing IBMQ API token?")


### PR DESCRIPTION
## Description

In order to access information about the start and end times of a computation, we need to have access to the provider. The easiest way to do that is by adding it as an attribute to the QiskitBackend.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
