### PR TITLE
fix: incorrectly formatted docstrings

### DIFF
--- a/src/orquestra/integrations/qiskit/conversions/_qiskit_expressions.py
+++ b/src/orquestra/integrations/qiskit/conversions/_qiskit_expressions.py
@@ -2,12 +2,6 @@
 # © Copyright 2021-2022 Zapata Computing Inc.
 ################################################################################
 """Translations between Qiskit parameter expressions and intermediate expression trees.
-
-Attributes:
-    QISKIT_DIALECT: Mapping from the intermediate expression tree into atoms
-        used in Qiskit symbolic expressions. Allows translating an expression
-        into the Qiskit dialect. Can be used with
-        `orquestra.quantum.circuits.symbolic.translations.translate_expression`.
 """
 import operator
 from functools import lru_cache, reduce, singledispatch
@@ -81,3 +75,8 @@ QISKIT_DIALECT = ExpressionDialect(
         "pow": integer_pow,
     },
 )
+"""Mapping from the intermediate expression tree into Qiskit symbolic expression atoms.
+        
+Allows translating an expression into the Qiskit dialect. Can be used with
+`orquestra.quantum.circuits.symbolic.translations.translate_expression`.
+"""

--- a/src/orquestra/integrations/qiskit/conversions/_qiskit_expressions.py
+++ b/src/orquestra/integrations/qiskit/conversions/_qiskit_expressions.py
@@ -76,7 +76,7 @@ QISKIT_DIALECT = ExpressionDialect(
     },
 )
 """Mapping from the intermediate expression tree into Qiskit symbolic expression atoms.
-        
+
 Allows translating an expression into the Qiskit dialect. Can be used with
 `orquestra.quantum.circuits.symbolic.translations.translate_expression`.
 """

--- a/src/orquestra/integrations/qiskit/simulator/_qiskit_wavefunction_simulator.py
+++ b/src/orquestra/integrations/qiskit/simulator/_qiskit_wavefunction_simulator.py
@@ -18,6 +18,11 @@ from orquestra.integrations.qiskit.runner._qiskit_runner import AnyQiskitBackend
 
 
 class QiskitWavefunctionSimulator(BaseWavefunctionSimulator):
+    """Wavefunction simulator using Qiskit backends.
+
+    Note that this simulator only works with backends that supports save_state
+    instruction.
+    """
     def __init__(
         self,
         qiskit_backend: AnyQiskitBackend,

--- a/src/orquestra/integrations/qiskit/simulator/_qiskit_wavefunction_simulator.py
+++ b/src/orquestra/integrations/qiskit/simulator/_qiskit_wavefunction_simulator.py
@@ -23,6 +23,7 @@ class QiskitWavefunctionSimulator(BaseWavefunctionSimulator):
     Note that this simulator only works with backends that supports save_state
     instruction.
     """
+
     def __init__(
         self,
         qiskit_backend: AnyQiskitBackend,


### PR DESCRIPTION
## Description

This fixes the docstrings formatting, thus reducing the number of errors/warnings occurring when building orquestra-core docs.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
