### PR TITLE
feat: add option to not return extra measurements

### DIFF
--- a/src/orquestra/integrations/qiskit/runner/_ibmq_runner.py
+++ b/src/orquestra/integrations/qiskit/runner/_ibmq_runner.py
@@ -39,6 +39,7 @@ def create_ibmq_runner(
     seed: Optional[int] = None,
     retry_delay_seconds: int = 60,
     retry_timeout_seconds: int = 24 * 60 * 60,  # default timeout of one day
+    discard_extra_measurements=False,
 ):
     try:
         IBMQ.enable_account(api_token)
@@ -61,4 +62,5 @@ def create_ibmq_runner(
         execute_function=_execute_on_ibmq_with_retries(
             retry_delay_seconds, retry_timeout_seconds
         ),
+        discard_extra_measurements=discard_extra_measurements,
     )

--- a/src/orquestra/integrations/qiskit/runner/_qiskit_runner.py
+++ b/src/orquestra/integrations/qiskit/runner/_qiskit_runner.py
@@ -101,9 +101,8 @@ class QiskitRunner(BaseCircuitRunner):
         # only one experiment. To simplify logic, we make sure to always have a
         # list of counts from a job.
 
-        # For whatever reason, one can use job.result().get_counts() to get all
-        # counts, but job.result().get_memory() does require index of the experiment
-        # ¯\_(ツ)_/¯
+        # One can use job.result().get_counts() to get all counts, but job.result().get_memory()
+        # does require index of the experiment
         # This is why the below list comprehension looks so clumsy.
         all_bitstrings = [
             job.result().get_memory(i)

--- a/src/orquestra/integrations/qiskit/runner/_qiskit_runner.py
+++ b/src/orquestra/integrations/qiskit/runner/_qiskit_runner.py
@@ -1,5 +1,6 @@
 from typing import List, Optional, Sequence, Union
 
+from orquestra.integrations.qiskit.conversions import export_to_qiskit
 from orquestra.quantum.api import BaseCircuitRunner
 from orquestra.quantum.circuits import (
     Circuit,
@@ -12,8 +13,6 @@ from qiskit import ClassicalRegister, QuantumCircuit, execute
 from qiskit.providers import BackendV1, BackendV2
 from qiskit.transpiler import CouplingMap
 from qiskit_aer.noise import NoiseModel
-
-from orquestra.integrations.qiskit.conversions import export_to_qiskit
 
 AnyQiskitBackend = Union[BackendV1, BackendV2]
 
@@ -101,8 +100,8 @@ class QiskitRunner(BaseCircuitRunner):
         # only one experiment. To simplify logic, we make sure to always have a
         # list of counts from a job.
 
-        # One can use job.result().get_counts() to get all counts, but job.result().get_memory()
-        # does require index of the experiment
+        # One can use job.result().get_counts() to get all counts, but
+        # job.result().get_memory() does require index of the experiment
         # This is why the below list comprehension looks so clumsy.
         all_bitstrings = [
             job.result().get_memory(i)

--- a/src/orquestra/integrations/qiskit/runner/_qiskit_runner.py
+++ b/src/orquestra/integrations/qiskit/runner/_qiskit_runner.py
@@ -1,6 +1,5 @@
 from typing import List, Optional, Sequence, Union
 
-from orquestra.integrations.qiskit.conversions import export_to_qiskit
 from orquestra.quantum.api import BaseCircuitRunner
 from orquestra.quantum.circuits import (
     Circuit,
@@ -13,6 +12,8 @@ from qiskit import ClassicalRegister, QuantumCircuit, execute
 from qiskit.providers import BackendV1, BackendV2
 from qiskit.transpiler import CouplingMap
 from qiskit_aer.noise import NoiseModel
+
+from orquestra.integrations.qiskit.conversions import export_to_qiskit
 
 AnyQiskitBackend = Union[BackendV1, BackendV2]
 

--- a/tests/orquestra/integrations/qiskit/runner/_ibmq_runner_test.py
+++ b/tests/orquestra/integrations/qiskit/runner/_ibmq_runner_test.py
@@ -33,3 +33,17 @@ def test_ibmq_runner_can_run_batches_larger_then_natively_supported_by_backend(
 
     result = ibmq_runner.run_batch_and_measure(circuits, 1000)
     assert len(result) == len(circuits)
+
+
+def test_ibmq_runner_discards_extra_measurements_if_exact_num_measurements_is_true():
+    ibmq_runner = create_ibmq_runner(
+        api_token=os.getenv("ZAPATA_IBMQ_API_TOKEN"),
+        backend_name="ibmq_qasm_simulator",
+        retry_delay_seconds=1,
+        discard_extra_measurements=True,
+    )
+    circuits = [Circuit([H(0), CNOT(0, 1)])] * 3
+    n_samples = [5, 10, 15]
+    result = ibmq_runner.run_batch_and_measure(circuits, n_samples=n_samples)
+
+    assert [len(r.bitstrings) for r in result] == n_samples

--- a/tests/orquestra/integrations/qiskit/runner/_qiskit_runner_test.py
+++ b/tests/orquestra/integrations/qiskit/runner/_qiskit_runner_test.py
@@ -139,10 +139,30 @@ def test_qiskit_runner_passes_coupling_map_to_execute_function():
     execute_func = Mock(wraps=execute)
 
     runner = QiskitRunner(
-        Aer.get_backend("statevector_simulator"),
+        Aer.get_backend("aer_simulator_statevector"),
         coupling_map=coupling_map,
         execute_function=execute_func,
     )
 
     runner.run_and_measure(circuit, n_samples=10)
     assert execute_func.call_args.kwargs["coupling_map"] == coupling_map
+
+
+@pytest.mark.parametrize(
+    "runner",
+    [
+        *[
+            QiskitRunner(Aer.get_backend(name), discard_extra_measurements=True)
+            for name in COMPATIBLE_BACKENDS
+        ]
+    ],
+    ids=_test_id,
+)
+def test_qiskit_runner_discards_extra_measurements_exact_num_measurements_is_true(
+    runner: QiskitRunner,
+):
+    circuits = [Circuit([X(0), CNOT(0, 1)])] * 3
+    n_samples = [5, 10, 15]
+    result = runner.run_batch_and_measure(circuits, n_samples=n_samples)
+
+    assert [len(r.bitstrings) for r in result] == n_samples

--- a/tests/orquestra/integrations/qiskit/runner/_qiskit_runner_test.py
+++ b/tests/orquestra/integrations/qiskit/runner/_qiskit_runner_test.py
@@ -12,8 +12,9 @@ from orquestra.quantum.circuits import CNOT, Circuit, H, X
 from orquestra.quantum.estimation import estimate_expectation_values_by_averaging
 from orquestra.quantum.measurements import ExpectationValues
 from orquestra.quantum.operators import PauliTerm
-from qiskit import Aer, QiskitError, execute
+from qiskit import QiskitError, execute
 from qiskit.transpiler import CouplingMap
+from qiskit_aer import Aer
 
 from orquestra.integrations.qiskit.noise import get_qiskit_noise_model
 from orquestra.integrations.qiskit.runner import QiskitRunner

--- a/tests/orquestra/integrations/qiskit/runner/_qiskit_wavefunction_simulator_test.py
+++ b/tests/orquestra/integrations/qiskit/runner/_qiskit_wavefunction_simulator_test.py
@@ -5,11 +5,11 @@ from orquestra.quantum.api.wavefunction_simulator_contracts import (
     simulator_contracts_with_nontrivial_initial_state,
 )
 from orquestra.quantum.circuits import CNOT, Circuit, X
-from qiskit import Aer
+from qiskit_aer import Aer
 
 from orquestra.integrations.qiskit.simulator import QiskitWavefunctionSimulator
 
-STATEVECTOR_BACKENDS = ["aer_simulator_statevector", "statevector_simulator"]
+STATEVECTOR_BACKENDS = ["aer_simulator_statevector"]
 
 
 def _test_id(val):


### PR DESCRIPTION
## Description

This adds an option to discard extra measurements in Qiskit runner. Also, a corresponding parameter `discard_extra_measurements` is added to `create_ibmq_runner` for the ease of use.

Additionally, this PR fixes several pending deprecation warnings by adjusting the Qiskit related imports.

Note: this PR needs https://github.com/zapatacomputing/orquestra-quantum/pull/79 to be merged first

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
